### PR TITLE
fix: [feedback/idea] Auto-dismiss of LogBox badges should run BOTH before AND after every interactive tool callÔÇª

### DIFF
--- a/android-mcp/src/index.ts
+++ b/android-mcp/src/index.ts
@@ -158,6 +158,12 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
           result.content.push({ type: "text", text: note });
         }
       }
+      // A LogBox badge spawned by this action often renders only after the
+      // screen settles — later than the eager dismiss above. Without a second
+      // pass it survives into the user's next screenshot/assert (which skip
+      // auto-dismiss), corrupting the result (issue #24). Now that the
+      // post-action UI has settled, clear any late-appearing badge.
+      try { await dismissDevOverlay(); } catch { /* best-effort */ }
     }
     const preview = result.content.find((c) => c.type === "text")?.text;
     recordCall(tool.name, args, !result.isError, preview);

--- a/android-mcp/src/tools.ts
+++ b/android-mcp/src/tools.ts
@@ -582,7 +582,7 @@ export const tools: Tool[] = [
   {
     name: "dismiss_dev_overlay",
     description:
-      "Dismiss React Native LogBox dev overlays (full-screen stack-trace view and minimized warning badges). Called automatically before every interactive tool; expose as an explicit tool for debugging.",
+      "Dismiss React Native LogBox dev overlays (full-screen stack-trace view and minimized warning badges). Called automatically before and after every interactive tool (after a short settle, so badges spawned by the action are cleared too); expose as an explicit tool for debugging.",
     schema: z.object({}),
     handler: async () => json(await dismissDevOverlay()),
   },


### PR DESCRIPTION
Fixes #24

Automated fix opened by the chrome-mcp issue-watcher. Review before merging.